### PR TITLE
CorrigidoBug

### DIFF
--- a/projeto-Api/src/db/bancoDados.js
+++ b/projeto-Api/src/db/bancoDados.js
@@ -28,7 +28,7 @@ class BancoDados {
     <p><span>Telefone:</span> ${cliente.telefone_fixo}</p>
     <p><span>E-mail:</span> ${cliente.email}</p>
     <p><span>Data de nascimento:</span> ${cliente.data_nasc}</p>
-    <p><span>Pedidos:</span> ${cliente.pedidos.join(', ')}.</p>
+    <p><span>Pedidos:</span> ${cliente.pedidos ? cliente.pedidos.join(', ') : 0}.</p>
     `;
 
     const button = document.createElement('button');


### PR DESCRIPTION
Quando é realizado o POST, o atributo pedidos, que é um array, do objeto body, não sobe para API. Por conta disso, o JavaScript estava quebrando, pois como não há pedidos, não tem como dar .join, logo não renderiza. Afim de ajudar os colegas, atualizei a linha 31.